### PR TITLE
Fix bug in resolution filtering for mixed resolutions

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -9317,6 +9317,12 @@ function parseAdvancedQuery(query) {
 
       if (field === "resolution") {
         addPred(row => {
+          // If mixed, check all resolutions in ResolutionAll
+          if (row.ResolutionMixed && row.ResolutionAll) {
+            const parts = row.ResolutionAll.split(",").map(s => s.trim());
+            const hit = parts.some(part => resolutionMatches(part, value));
+            return neg ? !hit : hit;
+          }
           const hit = resolutionMatches(getFieldValue(row, field), value);
           return neg ? !hit : hit;
         });


### PR DESCRIPTION
When the library contains series where mixed video resolutions are reported (such as the following: "1920x960p, 3840x1606p"; "1920x960p, 3840x1920p"; "3840x2160p, 1920x1080p") searching for "Resolution" "contains" "3840" only returns series where 3840 appears first in the mixed resolution list (or is the only resolution).